### PR TITLE
Update Bootlint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.4",
-    "bootlint": "^0.11.0",
+    "bootlint": "^0.12.0",
     "through2": "^0.6.3",
     "chalk": "^1.0.0"
   },


### PR DESCRIPTION
Update to Bootlint v0.12.0.

Closes #2
