### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@
  */
 
 'use strict';
-var gutil = require('gulp-util');
-var PluginError = gutil.PluginError;
+var colors = require('ansi-colors');
+var PluginError = require('plugin-error');
 var through = require('through2');
 var Log = require('log');
 var merge = require('merge');
@@ -32,7 +32,7 @@ function gulpBootlint(options) {
      * @param errorLocation Error location object.
      */
     var defaultReportFn = function(file, lint, isError, isWarning, errorLocation) {
-        var lintId = (isError) ? gutil.colors.bgRed.white(lint.id) : gutil.colors.bgYellow.white(lint.id);
+        var lintId = (isError) ? colors.bgred(colors.white(lint.id)) : colors.bgyellow(colors.white(lint.id));
         var message = '';
         if (errorLocation) {
             message = file.path + ':' + (errorLocation.line + 1) + ':' + (errorLocation.column + 1) + ' ' + lintId + ' ' + lint.message;
@@ -58,19 +58,19 @@ function gulpBootlint(options) {
         if (errorCount > 0 || warningCount > 0) {
             var message = '';
             if (errorCount > 0) {
-                message += gutil.colors.red(errorCount + ' lint ' + (errorCount === 1 ? 'error' : 'errors'));
+                message += colors.red(errorCount + ' lint ' + (errorCount === 1 ? 'error' : 'errors'));
             }
 
             if (warningCount > 0) {
                 if (errorCount > 0) {
                     message += ' and ';
                 }
-                message += gutil.colors.yellow(warningCount + ' lint ' + (warningCount === 1 ? 'warning' : 'warnings'));
+                message += colors.yellow(warningCount + ' lint ' + (warningCount === 1 ? 'warning' : 'warnings'));
             }
             message += ' found in file ' + file.path;
             log.notice(message);
         } else {
-            log.info(gutil.colors.green(file.path + ' is lint free!'));
+            log.info(colors.green(file.path + ' is lint free!'));
         }
     };
 
@@ -128,7 +128,7 @@ function gulpBootlint(options) {
             options.issues.push(lint);
         };
 
-        log.info(gutil.colors.gray('Linting file ' + file.path));
+        log.info(colors.gray('Linting file ' + file.path));
         bootlint.lintHtml(file.contents.toString(), reporter, options.disabledIds);
 
         if(options.summaryReportFn){

--- a/package.json
+++ b/package.json
@@ -36,16 +36,18 @@
     "checker"
   ],
   "dependencies": {
+    "ansi-colors": "^1.1.0",
     "bootlint": "^0.14.2",
-    "gulp-util": "^3.0.8",
     "log": "^1.4.0",
     "merge": "^1.2.0",
+    "plugin-error": "^1.0.1",
     "through2": "^2.0.3"
   },
   "devDependencies": {
     "eslint": "^3.14.1",
     "mocha": "^3.2.0",
-    "should": "^11.2.0"
+    "should": "^11.2.0",
+    "vinyl": "^2.1.0"
   },
   "readmeFilename": "README.md",
   "bugs": {

--- a/test/test.js
+++ b/test/test.js
@@ -11,13 +11,13 @@
 
 var bootlintPlugin = require('../');
 var should = require('should');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var fs = require('fs');
 var path = require('path');
 
 var getFile = function(filePath) {
     var fullFilePath = './test/' + filePath;
-    return new gutil.File({
+    return new Vinyl({
         path: fullFilePath,
         cwd: './test/',
         base: path.dirname(fullFilePath),
@@ -37,7 +37,7 @@ describe('gulp-bootlint', function() {
                 should.exist(file.path);
                 should.exist(file.relative);
                 should.exist(file.contents);
-                file.path.should.equal('./test/fixtures/valid-bootstrap.html');
+                file.path.should.equal(path.normalize('./test/fixtures/valid-bootstrap.html'));
                 file.relative.should.equal('valid-bootstrap.html');
                 ++fileCount;
             });


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp.

The [README.md](https://github.com/gulpjs/gulp-util) lists alternatives for all the components so a simple replacement should be enough.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143